### PR TITLE
fix: Resolve nested JSON schemas in documentation generation

### DIFF
--- a/jsonschema/docs/.snapshots/TestFiletypes.md
+++ b/jsonschema/docs/.snapshots/TestFiletypes.md
@@ -1,0 +1,43 @@
+# Table of contents
+
+* [`FileSpec`](#FileSpec)
+  * [`CSVSpec`](#CSVSpec)
+  * [`JSONSpec`](#JSONSpec)
+  * [`ParquetSpec`](#ParquetSpec)
+
+## <a name="FileSpec"></a>FileSpec
+
+* `format` (`string`) (required) (possible values: `csv`, `json`, `parquet`)
+
+  Output format.
+
+* `format_spec` ([`CSVSpec`](#CSVSpec), [`JSONSpec`](#JSONSpec) or [`ParquetSpec`](#ParquetSpec)) (nullable)
+
+* `compression` (`string`) (possible values: ` `, `gzip`)
+
+  Compression type.
+  Empty or missing stands for no compression.
+
+### <a name="CSVSpec"></a>CSVSpec
+
+  CloudQuery CSV file output spec.
+
+* `skip_header` (`boolean`) (default: `false`)
+
+  Specifies if the first line of a file should be the header.
+
+* `delimiter` (`string`) ([pattern](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.3.3): `^.$`) (default: `,`)
+
+  Character that will be used as the delimiter.
+
+### <a name="JSONSpec"></a>JSONSpec
+
+  CloudQuery JSON file output spec.
+
+(`object`)
+
+### <a name="ParquetSpec"></a>ParquetSpec
+
+  CloudQuery Parquet file output spec.
+
+(`object`)

--- a/jsonschema/docs/docs_test.go
+++ b/jsonschema/docs/docs_test.go
@@ -40,3 +40,7 @@ func TestGCP(t *testing.T) {
 func TestClickHouse(t *testing.T) {
 	genSnapshot(t, "testdata/clickhouse.json")
 }
+
+func TestFiletypes(t *testing.T) {
+	genSnapshot(t, "testdata/filetypes.json")
+}

--- a/jsonschema/docs/ref_key.go
+++ b/jsonschema/docs/ref_key.go
@@ -1,0 +1,36 @@
+package docs
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/invopop/jsonschema"
+)
+
+type refKey struct {
+	id  jsonschema.ID // $id of the schema, differs for nested schemas
+	key string        // key in definitions map
+}
+
+func (r refKey) unwrap() string {
+	return strings.TrimPrefix(r.key, "#/$defs/")
+}
+
+func (r refKey) name() string {
+	clashingRef := regexp.MustCompile(`^(.+)[_-]\d+$`)
+	key := r.unwrap()
+
+	match := clashingRef.FindStringSubmatch(key)
+	if len(match) > 1 {
+		return match[1]
+	}
+	return key
+}
+
+func (r refKey) anchor() string {
+	return strings.ReplaceAll(r.unwrap(), "_", "-")
+}
+
+func (r refKey) link() string {
+	return "[`" + r.name() + "`](#" + r.anchor() + ")"
+}

--- a/jsonschema/docs/reference.go
+++ b/jsonschema/docs/reference.go
@@ -1,0 +1,59 @@
+package docs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/invopop/jsonschema"
+)
+
+type reference struct {
+	key         refKey
+	level       int                    // header & nesting level
+	definitions jsonschema.Definitions // currently used definitions
+}
+
+func (r *reference) schema() (*jsonschema.Schema, error) {
+	key := r.key.unwrap()
+
+	sc, ok := r.definitions[key]
+	if !ok {
+		return nil, fmt.Errorf("missing definition for key %q, possibly incomplete schema", key)
+	}
+
+	return sc, nil
+}
+
+func (r *reference) header() string {
+	return strings.Repeat("#", min(r.level, 6)) + ` <a name="` + r.key.anchor() + `"></a>` + r.key.name()
+}
+
+func (r *reference) newReferences(sc *jsonschema.Schema, keys []refKey) []reference {
+	if len(keys) == 0 {
+		return nil
+	}
+
+	refs := make([]reference, len(keys))
+	for i, key := range keys {
+		refs[i] = r.newRef(sc, key)
+	}
+	return refs
+}
+
+func (r *reference) newRef(sc *jsonschema.Schema, key refKey) reference {
+	var defs jsonschema.Definitions
+	if len(key.id) == 0 {
+		key.id = sc.ID
+		defs = sc.Definitions
+	}
+	if len(key.id) == 0 {
+		key.id = r.key.id
+		defs = r.definitions
+	}
+
+	return reference{
+		key:         key,
+		level:       r.level + 1,
+		definitions: defs,
+	}
+}

--- a/jsonschema/docs/testdata/filetypes.json
+++ b/jsonschema/docs/testdata/filetypes.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cloudquery/filetypes/v4/file-spec",
+  "$ref": "#/$defs/FileSpec",
+  "$defs": {
+    "FileSpec": {
+      "$id": "/schemas/FileSpec",
+      "$defs": {
+        "CSVSpec": {
+          "properties": {
+            "skip_header": {
+              "type": "boolean",
+              "description": "Specifies if the first line of a file should be the header.",
+              "default": false
+            },
+            "delimiter": {
+              "type": "string",
+              "pattern": "^.$",
+              "description": "Character that will be used as the delimiter.",
+              "default": ","
+            }
+          },
+          "additionalProperties": false,
+          "type": "object",
+          "description": "CloudQuery CSV file output spec."
+        },
+        "JSONSpec": {
+          "additionalProperties": false,
+          "type": "object",
+          "description": "CloudQuery JSON file output spec."
+        },
+        "ParquetSpec": {
+          "additionalProperties": false,
+          "type": "object",
+          "description": "CloudQuery Parquet file output spec."
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "format": {
+              "type": "string",
+              "const": "csv"
+            },
+            "format_spec": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/CSVSpec"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "properties": {
+            "format": {
+              "type": "string",
+              "const": "json"
+            },
+            "format_spec": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/JSONSpec"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "properties": {
+            "format": {
+              "type": "string",
+              "const": "parquet"
+            },
+            "format_spec": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/ParquetSpec"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "properties": {
+        "format": {
+          "type": "string",
+          "enum": [
+            "csv",
+            "json",
+            "parquet"
+          ],
+          "description": "Output format."
+        },
+        "format_spec": {
+          "oneOf": [
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/CSVSpec"
+                },
+                {
+                  "$ref": "#/$defs/JSONSpec"
+                },
+                {
+                  "$ref": "#/$defs/ParquetSpec"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "compression": {
+          "type": "string",
+          "enum": [
+            "",
+            "gzip"
+          ],
+          "description": "Compression type.\nEmpty or missing stands for no compression."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "format"
+      ]
+    }
+  }
+}

--- a/jsonschema/docs/type_reference.go
+++ b/jsonschema/docs/type_reference.go
@@ -1,0 +1,25 @@
+package docs
+
+type typeReference struct {
+	name string
+	ref  *refKey
+}
+
+func (t typeReference) printable() string {
+	name := backtick(t.name) // backticks for type name
+	if t.ref == nil {
+		return name
+	}
+	return `[` + name + `](#` + t.ref.anchor() + `)` // link
+}
+
+func (t typeReference) refs() []refKey {
+	if t.ref == nil {
+		return nil
+	}
+	return []refKey{*t.ref}
+}
+
+func backtick(s string) string {
+	return "`" + s + "`"
+}


### PR DESCRIPTION
* Traverse `anyOf` & `oneOf` types when generating docs from JSON schema
* Properly handle new roots (when `$id` is defined)