### PR TITLE
fix: Make generating docs non destructive

### DIFF
--- a/jsonschema/docs/docs.go
+++ b/jsonschema/docs/docs.go
@@ -131,7 +131,7 @@ func writeProperty(property *jsonschema.Schema, required bool, buff *strings.Bui
 }
 
 func writeDescription(sc *jsonschema.Schema, buff *strings.Builder) {
-	if len(sc.Description) == 0 {
+	if len(sc.Description) == 0 || sc.Comments == "skip_description" {
 		return
 	}
 
@@ -139,7 +139,7 @@ func writeDescription(sc *jsonschema.Schema, buff *strings.Builder) {
 	buff.WriteString(strings.ReplaceAll(sc.Description, "\n", "\n  "))
 	buff.WriteString("\n")
 
-	sc.Description = "" // already used
+	sc.Comments = "skip_description"
 }
 
 func writeValueAnnotations(sc *jsonschema.Schema, buff *strings.Builder) {

--- a/jsonschema/docs/docs.go
+++ b/jsonschema/docs/docs.go
@@ -17,6 +17,8 @@ func generateDoc(root jsonschema.Schema, headerLevel int) (string, error) {
 	return toc + "\n\n" + buff.String(), err
 }
 
+// GenerateFromSchema generates a markdown documentation from a jsonschema.Schema. During the writing process the `Comment` attribute can be overwritten
+// To avoid this use the `Generate` function which will not modify the original schema
 func GenerateFromSchema(schema jsonschema.Schema, headerLevel int) (string, error) {
 	return generateDoc(schema, headerLevel)
 }

--- a/jsonschema/docs/docs_test.go
+++ b/jsonschema/docs/docs_test.go
@@ -28,6 +28,8 @@ func genSnapshot(t *testing.T, fileName string) {
 	doc, err := Generate(data, 1)
 	require.NoError(t, err)
 
+	// print(normalizeContent(doc))
+
 	cupaloy.New(cupaloy.SnapshotFileExtension(".md")).SnapshotT(t, normalizeContent(doc))
 }
 
@@ -58,18 +60,18 @@ func TestGCP(t *testing.T) {
 
 func TestClickHouse(t *testing.T) {
 	genSnapshot(t, "testdata/clickhouse.json")
-	genSnapshot(t, "testdata/clickhouse.json")
+	genSnapshotStruct(t, "testdata/clickhouse.json")
 
 }
 
 func TestFiletypes(t *testing.T) {
 	genSnapshot(t, "testdata/filetypes.json")
-	genSnapshot(t, "testdata/filetypes.json")
+	genSnapshotStruct(t, "testdata/filetypes.json")
 
 }
 
 func TestFileDestination(t *testing.T) {
 	genSnapshot(t, "testdata/file-destination.json")
-	genSnapshot(t, "testdata/file-destination.json")
+	genSnapshotStruct(t, "testdata/file-destination.json")
 
 }

--- a/jsonschema/docs/docs_test.go
+++ b/jsonschema/docs/docs_test.go
@@ -28,8 +28,6 @@ func genSnapshot(t *testing.T, fileName string) {
 	doc, err := Generate(data, 1)
 	require.NoError(t, err)
 
-	// print(normalizeContent(doc))
-
 	cupaloy.New(cupaloy.SnapshotFileExtension(".md")).SnapshotT(t, normalizeContent(doc))
 }
 


### PR DESCRIPTION
#### Summary

Before this change, after the first time a description was written to the string it would be deleted. Because all of the `schema` objects are passed by reference, this means that it would be permanently deleted if the initial object is passed in as a struct and not marshaled/unmarshaled.

This PR removes that specific destructive aspect and instead overwrites the `Comments` attribute which we do not use. This change doesn't impact any existing code as all instances still use the `Generate` rather than the `GenerateFromSchema`